### PR TITLE
Bugfix/georeference fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2024-12-10
+
+### Fixed
+
+* Fixed importing RD geo-referenced obj models to no longer have issues with floating point precision.
+
 ## [1.2.0] - 2024-12-05
 
 ### Added

--- a/Runtime/Scripts/General/CreateGameObjects.cs
+++ b/Runtime/Scripts/General/CreateGameObjects.cs
@@ -49,6 +49,7 @@ namespace Netherlands3D.ObjImporter.General
             time = System.DateTime.UtcNow;
             parentobject = new GameObject();
             parentobject.name = gameObjectData.name;
+            parentobject.transform.position = gameobjectDataset.Origin;
             totalgameobjects = gameObjectData.gameObjects.Count;
             gameobjectindex = 0;
             StartCoroutine(createGameObjects());
@@ -98,7 +99,7 @@ namespace Netherlands3D.ObjImporter.General
             }
 
             gameobject.name = gameobjectdata.name;
-            gameobject.transform.parent = parentobject.transform;
+            gameobject.transform.SetParent(parentobject.transform, false);
 
             yield return StartCoroutine(CreateMesh(gameobjectdata.meshdata));
 

--- a/Runtime/Scripts/General/GameObjectDataSet/GameObjectDataSet.cs
+++ b/Runtime/Scripts/General/GameObjectDataSet/GameObjectDataSet.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System;
+using UnityEngine;
 
 namespace Netherlands3D.ObjImporter.General.GameObjectDataSet
 {
@@ -9,6 +10,7 @@ namespace Netherlands3D.ObjImporter.General.GameObjectDataSet
         public string name;
         public List<MaterialData> materials = new List<MaterialData>();
         public List<GameObjectData> gameObjects = new List<GameObjectData>();
+        public Vector3 Origin = Vector3.zero;
         public void Clear()
         {
             foreach (GameObjectData item in gameObjects)

--- a/Runtime/Scripts/ObjImporter.cs
+++ b/Runtime/Scripts/ObjImporter.cs
@@ -87,7 +87,6 @@ namespace Netherlands3D.ObjImporter
             objreader.broadcastProgressPercentage = BroadcastProgressPercentage;
             objreader.BroadcastErrorMessage = BroadcastErrormessage;
 
-
             BroadcastCurrentActivity("obj-bestand inlezen");
 
             objreader.ReadOBJ(objFilePath, OnOBJRead);
@@ -107,7 +106,7 @@ namespace Netherlands3D.ObjImporter
             Debug.Log("cancelling StreamReadOBJ");
         }
 
-
+        public Bounds testBounds = new();
         private void OnOBJRead(bool succes)
         {
             if (!succes) //something went wrong
@@ -120,6 +119,13 @@ namespace Netherlands3D.ObjImporter
                 return;
             }
             createdGameobjectIsMoveable = !objreader.ObjectUsesRDCoordinates;
+            if (objreader.ObjectUsesRDCoordinates)
+            {
+                transform.position = objreader.RDOrigin.ToUnity();
+            }
+
+            testBounds = objreader.testBounds;
+            
             ObjImportSucceeded?.Invoke(succes);
             
             if (mtlFilePath != "")
@@ -186,6 +192,8 @@ namespace Netherlands3D.ObjImporter
             objectDataCreator.normals = objreader.normals;
             objectDataCreator.uvs = objreader.uvs;
             objectDataCreator.broadcastProgressPercentage = progressPercentage;
+            if(objreader.ObjectUsesRDCoordinates)
+                objectDataCreator.origin = objreader.RDOrigin.ToUnity();
 
             List<Submesh> submeshes = new List<Submesh>();
             foreach (KeyValuePair<string, Submesh> kvp in objreader.submeshes)
@@ -194,7 +202,6 @@ namespace Netherlands3D.ObjImporter
             }
             objectDataCreator.submeshes = submeshes;
             objectDataCreator.CreateGameObjectDataSet(OnGameObjectDataSetCreated, !createSubMeshes);
-
         }
 
         void OnGameObjectDataSetCreated(GameObjectDataSet gods)

--- a/Runtime/Scripts/ObjImporter.cs
+++ b/Runtime/Scripts/ObjImporter.cs
@@ -106,7 +106,6 @@ namespace Netherlands3D.ObjImporter
             Debug.Log("cancelling StreamReadOBJ");
         }
 
-        public Bounds testBounds = new();
         private void OnOBJRead(bool succes)
         {
             if (!succes) //something went wrong
@@ -123,8 +122,6 @@ namespace Netherlands3D.ObjImporter
             {
                 transform.position = objreader.RDOrigin.ToUnity();
             }
-
-            testBounds = objreader.testBounds;
             
             ObjImportSucceeded?.Invoke(succes);
             

--- a/Runtime/Scripts/ParseOBJ/CreateGameObjectDataSetFromOBJ.cs
+++ b/Runtime/Scripts/ParseOBJ/CreateGameObjectDataSetFromOBJ.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Netherlands3D.ObjImporter.General.GameObjectDataSet;
 using UnityEngine;
 
-
 namespace Netherlands3D.ObjImporter.ParseOBJ
 {
     public class CreateGameObjectDataSetFromOBJ : MonoBehaviour
@@ -31,7 +30,8 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
         public Vector3List normals = new Vector3List();
         public Vector2List uvs = new Vector2List();
         public List<Submesh> submeshes;
-
+        public Vector3 origin;
+        
         // variable for creating the dataset
         Vector3List meshVertices = new Vector3List();
         Vector3List meshNormals = new Vector3List();
@@ -43,7 +43,6 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
         GameObjectDataSet container = new GameObjectDataSet();
         SubMeshRawData rawdata = new SubMeshRawData();
         int nextindex = 0;
-
 
         // variable for string the returnAdress
         System.Action<GameObjectDataSet> callback;
@@ -60,10 +59,9 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
 
         public void CreateGameObjectDataSet(System.Action<GameObjectDataSet> callbacktoFunction,bool createMultipleObjects=false)
         {
-
-
             needToCancel = false;
             container = new GameObjectDataSet();
+            container.Origin = origin;
             
             totalSubmeshCount = submeshes.Count;
             currentSubmeshindex = 0;

--- a/Runtime/Scripts/ParseOBJ/StreamreadOBJ.cs
+++ b/Runtime/Scripts/ParseOBJ/StreamreadOBJ.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -11,8 +12,8 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
     public class StreamreadOBJ : MonoBehaviour
     {
         const string glyphs = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"; //add the characters you want
-        public System.Action<float> broadcastProgressPercentage;
-        public System.Action<string> BroadcastErrorMessage;
+        public Action<float> broadcastProgressPercentage;
+        public Action<string> BroadcastErrorMessage;
         bool needToCancel;
         StringBuilder sb = new StringBuilder();
         [HideInInspector]
@@ -55,9 +56,11 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
         private bool RDCoordinates = false;
         private bool flipFaceDirection = false; // set to true if windingOrder in obj-file is not the standard CounterClockWise
         private bool flipYZ = false; // set to true if Y and Z axes in the obj have been flipped	
+        private Coordinate rdOrigin; // if an object uses RD coordinates, we need to offset all the vertices so we don't get floating point issues in the mesh. the parsed GameObject is then set to this position to maintain the georeference. 
         public bool ObjectUsesRDCoordinates { get => RDCoordinates; set => RDCoordinates = value; }
-        public bool FlipYZ { get => flipYZ; set => flipYZ = value; }
         public bool FlipFaceDirection { get => flipFaceDirection; set => flipFaceDirection = value; }
+        public bool FlipYZ { get => flipYZ; set => flipYZ = value; }
+        public Coordinate RDOrigin => rdOrigin;
         SubMeshRawData rawdata = new SubMeshRawData();
         StreamReader streamReader;
         [HideInInspector]
@@ -92,7 +95,6 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                     if (submeshes.ContainsKey(activeSubmesh.name))
                     {
                         submeshes[activeSubmesh.name] = activeSubmesh;
-
                     }
                 }
                 else
@@ -238,13 +240,12 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                     yield break;
                 }
             }
-
+            
             streamReader.Close();
             fileStream.Close();
             vertices.EndWriting();
             normals.EndWriting();
             uvs.EndWriting();
-
 
             rawdata.EndWriting();
 
@@ -591,13 +592,14 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
             }
         }
 
+        public Bounds testBounds = new Bounds();
         void ReadVertex()
         {
-            float x = ReadFloat();
-            float y = ReadFloat();
-            float z = ReadFloat();
+            double x = ReadDouble(); //we initially read as doubles, because we need the precision in case the model is geo-referenced
+            double y = ReadDouble();
+            double z = ReadDouble();
 
-            if (x != float.NaN && y != float.NaN & z != float.NaN)
+            if (x != double.NaN && y != double.NaN & z != double.NaN)
             {
                 if (vertices.Count() == 0)
                 {// this is the first vertex, check if it is in rd-coordinates
@@ -605,53 +607,67 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                 }
                 if (ObjectUsesRDCoordinates)
                 {
-                    Vector3 coord;
+                    double[] coord = new double[3];
                     if (flipYZ)
                     {
-                        
-                        Coordinate coordinate = CoordinateConverter.ConvertTo(new Coordinate(CoordinateSystem.RD, new double[3] { x, z, y }),CoordinateSystem.Unity);
-                        coord = coordinate.ToVector3();
+                        // Coordinate coordinate = CoordinateConverter.ConvertTo(new Coordinate(CoordinateSystem.RD, new double[3] { x, z, y }),CoordinateSystem.Unity);
+                        // coord = coordinate.ToVector3();
+                        // Coordinate coordinate = new Coordinate(CoordinateSystem.RDNAP, new double[3] { x, z, y });
+                        // coord = (coordinate - rdOrigin).ToVector3();
+                        coord[0] = x - rdOrigin.easting;
+                        coord[1] = z - rdOrigin.northing;
+                        coord[2] = y;
                     }
                     else
                     {
-                        Coordinate coordinate = CoordinateConverter.ConvertTo(new Coordinate(CoordinateSystem.RD, new double[3] { x, y, z }), CoordinateSystem.Unity);
-                        coord = coordinate.ToVector3();
-                       
+                        // Coordinate coordinate = CoordinateConverter.ConvertTo(new Coordinate(CoordinateSystem.RD, new double[3] { x, y, z }), CoordinateSystem.Unity);
+                        // coord = coordinate.ToVector3();
+                        // Coordinate coordinate = new Coordinate(CoordinateSystem.RDNAP, new double[3] { x, y, z });
+                        // coord = (coordinate - rdOrigin).ToVector3();
+                        coord[0] = x - rdOrigin.easting;
+                        coord[1] = y - rdOrigin.northing;
+                        coord[2] = z;
                     }
-                    vertices.Add(coord.x, coord.y, coord.z);
+
+                    testBounds.Encapsulate(new Vector3((float)coord[0], (float)coord[1], (float)coord[2]));
+                    vertices.Add((float)coord[0], (float)coord[1], (float)coord[2]);
                     return;
                 }
 
                 if (FlipYZ)
                 {
-                    vertices.Add(x, z, y);
-
+                    testBounds.Encapsulate(new Vector3((float)x, (float)z, (float)y));
+                    vertices.Add((float)x, (float)z, (float)y);
                 }
                 else
                 {
-                    vertices.Add(x, y, -z);
+                    testBounds.Encapsulate(new Vector3((float)x, (float)y, (float)-z));
+                    vertices.Add((float)x, (float)y, (float)-z);
                 }
             }
         }
-        void CheckForRD(float x, float y, float z)
+        void CheckForRD(double x, double y, double z)
         {
-            
+            print("first vertex: " + x + "," + y + "," + z);
             if (EPSG7415.IsValid(new Vector3RD(x, z, y)))
             {
                 ObjectUsesRDCoordinates = true;
                 FlipYZ = true;
+                rdOrigin = new Coordinate(CoordinateSystem.RDNAP, x, z, y);
+                print("setting origin xzy: " + rdOrigin.ToUnity());
             }
             else if (EPSG7415.IsValid(new Vector3RD(x, y, z)))
             {
                 ObjectUsesRDCoordinates = true;
                 FlipYZ = false;
+                rdOrigin = new Coordinate(CoordinateSystem.RDNAP, x, y, z);
+                print("setting origin xyz: " + rdOrigin.ToUnity());
             }
             else
             {
                 ObjectUsesRDCoordinates = false;
                 FlipYZ = false;
             }
-
         }
 
         void ReadVertexTexture()
@@ -784,14 +800,10 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                             face.vertexNormal = number - 1;
                         }
                     }
-
                 }
-
-
-
             }
-            else
-            {// couldn't read a valid integer
+            else // couldn't read a valid integer
+            {
                 faceIndex = face;
                 readChar = lastChar;
                 return false;
@@ -867,6 +879,11 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
 
         float ReadFloat()
         {
+            return (float)ReadDouble();
+        }
+        
+        double ReadDouble()
+        {
             char readChar;
             bool numberFound = false;
             long number = 0;
@@ -877,6 +894,7 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
             int exponentSign = 1;
             int exponent = 0;
             bool keepGoing = true;
+
             while (keepGoing)
             {
                 if (NextChar(out readChar))
@@ -884,39 +902,29 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                     switch (readChar)
                     {
                         case '\0':
-                            //found a null-value
-                            if (numberFound)
-                            { // if we start with a space we continue
-                                keepGoing = false;
-                            }
-                            break;
                         case ' ':
-                            //found a space
+                        case '\r':
+                        case '\n':
+                            // End of the number
                             if (numberFound)
-                            { // if we start with a space we continue
+                            {
                                 keepGoing = false;
                             }
                             break;
-                        case '\r':
-                            // end of the line, end of the floatvalue
-                            keepGoing = false;
-                            break;
-                        case '\n':
-                            // end of the line, end of the floatvalue
-                            keepGoing = false;
-                            break;
+
                         case '.':
-                            // found a decimalpoint
+                            // Found a decimal point
                             isDecimal = true;
                             break;
+
                         case 'e':
                             if (numberFound)
                             {
                                 hasExponent = true;
                             }
                             break;
+
                         case '-':
-                            // found a negative-sign
                             if (hasExponent)
                             {
                                 exponentSign = -1;
@@ -926,17 +934,13 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                                 sign = -1;
                             }
                             break;
+
                         default:
-                            // no space or endof the line
                             if (isDigit(readChar))
-                            //if (char.IsDigit(readChar))
                             {
                                 numberFound = true;
                                 if (!hasExponent)
                                 {
-
-
-                                    //number = (number * 10) + (int)char.GetNumericValue(readChar);
                                     number = (number * 10) + (int)readChar - 48;
 
                                     if (isDecimal)
@@ -946,33 +950,39 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                                 }
                                 else
                                 {
-                                    exponent = (exponent * 10) + (int)readChar - 48; ;
+                                    exponent = (exponent * 10) + (int)readChar - 48;
                                 }
                             }
                             else
-                            {// found something else, so we stop
+                            {
+                                // Found something invalid, so we stop
                                 keepGoing = false;
                             }
                             break;
                     }
                 }
-                else { keepGoing = false; }
+                else
+                {
+                    keepGoing = false;
+                }
             }
+
             if (numberFound)
             {
-                float value = sign * number / (Mathf.Pow(10, decimalPlaces));
+                double value = sign * number / Math.Pow(10, decimalPlaces);
                 if (hasExponent)
                 {
-                    value *= Mathf.Pow(10, (exponentSign * exponent));
+                    value *= Math.Pow(10, (exponentSign * exponent));
                 }
                 return value;
             }
             else
-            { // no number found, so we return NAN;
-                return float.NaN;
+            {
+                // No number found, so we return NaN
+                return double.NaN;
             }
-
         }
+        
         bool isDigit(char character)
         {
             int waarde = (int)character;
@@ -988,15 +998,6 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
 
         private bool NextChar(out char character)
         {
-
-            //if (streamReader.Peek() > -1)
-            //{
-            //	character = (char)streamReader.Read();
-            //	return true;
-            //}
-            //character = 'e';
-            //return false;
-
             if (currentcharindex == charlistlength)
             {
                 //currentCharStartIndex += 100;
@@ -1029,7 +1030,7 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
             string returnstring = "";
             for (int i = 0; i < length; i++)
             {
-                returnstring += glyphs[Random.Range(0, glyphs.Length)];
+                returnstring += glyphs[UnityEngine.Random.Range(0, glyphs.Length)];
             }
             return returnstring;
         }

--- a/Runtime/Scripts/ParseOBJ/StreamreadOBJ.cs
+++ b/Runtime/Scripts/ParseOBJ/StreamreadOBJ.cs
@@ -636,13 +636,13 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
             {
                 ObjectUsesRDCoordinates = true;
                 FlipYZ = true;
-                rdOrigin = new Coordinate(CoordinateSystem.RDNAP, x, z, y);
+                rdOrigin = new Coordinate(CoordinateSystem.RDNAP, x, z, 0); //don't offset the height
             }
             else if (EPSG7415.IsValid(new Vector3RD(x, y, z)))
             {
                 ObjectUsesRDCoordinates = true;
                 FlipYZ = false;
-                rdOrigin = new Coordinate(CoordinateSystem.RDNAP, x, y, z);
+                rdOrigin = new Coordinate(CoordinateSystem.RDNAP, x, y, 0); //don't offset the height
             }
             else
             {

--- a/Runtime/Scripts/ParseOBJ/StreamreadOBJ.cs
+++ b/Runtime/Scripts/ParseOBJ/StreamreadOBJ.cs
@@ -592,7 +592,6 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
             }
         }
 
-        public Bounds testBounds = new Bounds();
         void ReadVertex()
         {
             double x = ReadDouble(); //we initially read as doubles, because we need the precision in case the model is geo-referenced
@@ -610,47 +609,29 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                     Coordinate coordinate;
                     if (flipYZ)
                     {
-                        // Coordinate coordinate = CoordinateConverter.ConvertTo(new Coordinate(CoordinateSystem.RD, new double[3] { x, z, y }),CoordinateSystem.Unity);
-                        // coord = coordinate.ToVector3();
-                        // Coordinate coordinate = new Coordinate(CoordinateSystem.RDNAP, new double[3] { x, z, y });
-                        // coord = (coordinate - rdOrigin).ToVector3();
                         coordinate = new Coordinate(CoordinateSystem.RDNAP, x - rdOrigin.easting, z - rdOrigin.northing, y);
-                        // coord[0] = coordinate.easting;
-                        // coord[1] = coordinate.height; //in our unity world y is up, so we need to put the up component in the y slot
-                        // coord[2] = coordinate.northing;
                     }
                     else
                     {
-                        // Coordinate coordinate = CoordinateConverter.ConvertTo(new Coordinate(CoordinateSystem.RD, new double[3] { x, y, z }), CoordinateSystem.Unity);
-                        // coord = coordinate.ToVector3();
-                        // Coordinate coordinate = new Coordinate(CoordinateSystem.RDNAP, new double[3] { x, y, z });
-                        // coord = (coordinate - rdOrigin).ToVector3();
                         coordinate = new Coordinate(CoordinateSystem.RDNAP, x - rdOrigin.easting, y - rdOrigin.northing, z);
-                        // coord[0] = x - rdOrigin.easting;
-                        // coord[1] = y - rdOrigin.northing;
-                        // coord[2] = z;
                     }
 
-                    testBounds.Encapsulate(new Vector3((float)coordinate.easting, (float)coordinate.height, (float)coordinate.northing));
                     vertices.Add((float)coordinate.easting, (float)coordinate.height, (float)coordinate.northing); //in our unity world y is up, so we need to put the up component in the y slot
                     return;
                 }
 
                 if (FlipYZ)
                 {
-                    testBounds.Encapsulate(new Vector3((float)x, (float)z, (float)y));
                     vertices.Add((float)x, (float)z, (float)y);
                 }
                 else
                 {
-                    testBounds.Encapsulate(new Vector3((float)x, (float)y, (float)-z));
                     vertices.Add((float)x, (float)y, (float)-z);
                 }
             }
         }
         void CheckForRD(double x, double y, double z)
         {
-            print("first vertex: " + x + "," + y + "," + z);
             if (EPSG7415.IsValid(new Vector3RD(x, z, y)))
             {
                 ObjectUsesRDCoordinates = true;
@@ -662,7 +643,6 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                 ObjectUsesRDCoordinates = true;
                 FlipYZ = false;
                 rdOrigin = new Coordinate(CoordinateSystem.RDNAP, x, y, z);
-                print("setting origin xyz: " + rdOrigin.ToUnity());
             }
             else
             {
@@ -677,7 +657,6 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
             float y = ReadFloat();
             if (x != float.NaN && y != float.NaN)
             {
-                //buffer.PushUV(new Vector2(x, y));
                 uvs.Add(x, y);
             }
         }

--- a/Runtime/Scripts/ParseOBJ/StreamreadOBJ.cs
+++ b/Runtime/Scripts/ParseOBJ/StreamreadOBJ.cs
@@ -607,16 +607,17 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                 }
                 if (ObjectUsesRDCoordinates)
                 {
-                    double[] coord = new double[3];
+                    Coordinate coordinate;
                     if (flipYZ)
                     {
                         // Coordinate coordinate = CoordinateConverter.ConvertTo(new Coordinate(CoordinateSystem.RD, new double[3] { x, z, y }),CoordinateSystem.Unity);
                         // coord = coordinate.ToVector3();
                         // Coordinate coordinate = new Coordinate(CoordinateSystem.RDNAP, new double[3] { x, z, y });
                         // coord = (coordinate - rdOrigin).ToVector3();
-                        coord[0] = x - rdOrigin.easting;
-                        coord[1] = z - rdOrigin.northing;
-                        coord[2] = y;
+                        coordinate = new Coordinate(CoordinateSystem.RDNAP, x - rdOrigin.easting, z - rdOrigin.northing, y);
+                        // coord[0] = coordinate.easting;
+                        // coord[1] = coordinate.height; //in our unity world y is up, so we need to put the up component in the y slot
+                        // coord[2] = coordinate.northing;
                     }
                     else
                     {
@@ -624,13 +625,14 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                         // coord = coordinate.ToVector3();
                         // Coordinate coordinate = new Coordinate(CoordinateSystem.RDNAP, new double[3] { x, y, z });
                         // coord = (coordinate - rdOrigin).ToVector3();
-                        coord[0] = x - rdOrigin.easting;
-                        coord[1] = y - rdOrigin.northing;
-                        coord[2] = z;
+                        coordinate = new Coordinate(CoordinateSystem.RDNAP, x - rdOrigin.easting, y - rdOrigin.northing, z);
+                        // coord[0] = x - rdOrigin.easting;
+                        // coord[1] = y - rdOrigin.northing;
+                        // coord[2] = z;
                     }
 
-                    testBounds.Encapsulate(new Vector3((float)coord[0], (float)coord[1], (float)coord[2]));
-                    vertices.Add((float)coord[0], (float)coord[1], (float)coord[2]);
+                    testBounds.Encapsulate(new Vector3((float)coordinate.easting, (float)coordinate.height, (float)coordinate.northing));
+                    vertices.Add((float)coordinate.easting, (float)coordinate.height, (float)coordinate.northing); //in our unity world y is up, so we need to put the up component in the y slot
                     return;
                 }
 
@@ -654,7 +656,6 @@ namespace Netherlands3D.ObjImporter.ParseOBJ
                 ObjectUsesRDCoordinates = true;
                 FlipYZ = true;
                 rdOrigin = new Coordinate(CoordinateSystem.RDNAP, x, z, y);
-                print("setting origin xzy: " + rdOrigin.ToUnity());
             }
             else if (EPSG7415.IsValid(new Vector3RD(x, y, z)))
             {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.obj-importer",
   "displayName": "Netherlands3D - Import .obj files",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "unity": "2022.2",
   "type": "library",
   "keywords": [


### PR DESCRIPTION
Fixed floating point importer issues for georeferenced obj files by offsettting the vertices so all these vertices are within a reasonable range, and then offsetting the returned object by the initial offset to place the object back at the original position. This allows the floating origin system to work with this offset and keep the model from deforming.